### PR TITLE
Update the VPC peering

### DIFF
--- a/hcp_consul_vpc/variables.tf
+++ b/hcp_consul_vpc/variables.tf
@@ -18,3 +18,13 @@ variable "cloud_provider" {
   type        = string
   default     = "aws"
 }
+variable "peering_id" {
+  description = "The ID of the HCP peering connection."
+  type        = string
+  default     = "learn-peering"
+}
+variable "route_id" {
+  description = "The ID of the HCP HVN route."
+  type        = string
+  default     = "learn-hvn-route"
+}

--- a/hcp_consul_vpc/vpc_peering.tf
+++ b/hcp_consul_vpc/vpc_peering.tf
@@ -12,6 +12,7 @@ data "aws_arn" "peer" {
 
 resource "hcp_aws_network_peering" "peer" {
   hvn_id              = hcp_hvn.example_hvn.hvn_id
+  peering_id          = var.peering_id
   peer_vpc_id         = aws_vpc.peer.id
   peer_account_id     = aws_vpc.peer.owner_id
   peer_vpc_region     = data.aws_arn.peer.region

--- a/hcp_consul_vpc/vpc_peering.tf
+++ b/hcp_consul_vpc/vpc_peering.tf
@@ -15,10 +15,17 @@ resource "hcp_aws_network_peering" "peer" {
   peer_vpc_id         = aws_vpc.peer.id
   peer_account_id     = aws_vpc.peer.owner_id
   peer_vpc_region     = data.aws_arn.peer.region
-  peer_vpc_cidr_block = aws_vpc.peer.cidr_block
+}
+
+resource "hcp_hvn_route" "peer_route" {
+  hvn_link         = hcp_hvn.example_hvn.self_link
+  hvn_route_id     = var.route_id
+  destination_cidr = aws_vpc.peer.cidr_block
+  target_link      = hcp_aws_network_peering.peer.self_link
 }
 
 resource "aws_vpc_peering_connection_accepter" "peer" {
   vpc_peering_connection_id = hcp_aws_network_peering.peer.provider_peering_id
   auto_accept               = true
 }
+


### PR DESCRIPTION
This PR updates the `variables.tf` and `vpc_peering.tf` files to match the recent change. 

Must be merged alongside of the [Learn tutorial PR 3622](https://github.com/hashicorp/learn/pull/3622).